### PR TITLE
Add Streaming JSON parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 PATH
   remote: .
   specs:
-    ps_utilities (1.0.2)
+    ps_utilities (1.1.0)
       httparty (~> 0.18)
+      oj (~> 3.13)
+      piperator (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -13,13 +15,15 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (1.0.1)
-    httparty (0.18.0)
+    httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2022.0105)
     multi_xml (0.6.0)
+    oj (3.13.23)
+    piperator (1.2.0)
     public_suffix (4.0.3)
     rake (13.0.1)
     rspec (3.9.0)
@@ -52,4 +56,4 @@ DEPENDENCIES
   webmock (~> 3.8)
 
 BUNDLED WITH
-   2.1.2
+   2.3.9

--- a/lib/ps_utilities/stream_parser.rb
+++ b/lib/ps_utilities/stream_parser.rb
@@ -1,0 +1,73 @@
+require 'oj'
+require 'piperator'
+
+# https://coderwall.com/p/l1omyw/ruby-reading-parsing-and-forwarding-large-json-files-in-small-chunks-i-e-streaming
+
+module PowerSchool
+  class StreamParser < ::Oj::ScHandler
+    def initialize(&block)
+      @path = []
+      @yield_record = block
+      @count = nil
+    end
+
+    def run(enumerable_data_source)
+      io = Piperator::IO.new(enumerable_data_source)
+      Oj.sc_parse(self, io)
+    end
+
+    def hash_start
+      update_path(:hash_start)
+      {}
+    end
+
+    def hash_end
+      update_path(:hash_end)
+    end
+
+    def hash_key(key)
+      update_path(:hash_key, key)
+      key
+    end
+
+    def hash_set(hash, key, value)
+      return if @path == ['record']
+
+      @count = value if @path == ['count']
+      hash[key] = value
+    end
+
+    def array_start
+      update_path(:array_start)
+      []
+    end
+
+    def array_end
+      update_path(:array_end)
+    end
+
+    def array_append(array, value)
+      index = update_path(:array_append)
+      if @path[..0] == ['record']
+        @yield_record.call(value, index, @count)
+      else
+        array << value
+      end
+    end
+
+    private
+
+    def update_path(method, key = nil)
+      case method
+      when :hash_start, :array_start
+        @path << nil
+      when :hash_end, :array_end
+        @path.pop
+      when :hash_key
+        @path[@path.length - 1] = key
+      when :array_append
+        @path[@path.length - 1] = @path.last.to_i + 1
+      end
+    end
+  end
+end

--- a/lib/ps_utilities/stream_parser.rb
+++ b/lib/ps_utilities/stream_parser.rb
@@ -3,7 +3,7 @@ require 'piperator'
 
 # https://coderwall.com/p/l1omyw/ruby-reading-parsing-and-forwarding-large-json-files-in-small-chunks-i-e-streaming
 
-module PowerSchool
+module PsUtilities
   class StreamParser < ::Oj::ScHandler
     def initialize(&block)
       @path = []

--- a/lib/ps_utilities/stream_parser.rb
+++ b/lib/ps_utilities/stream_parser.rb
@@ -49,7 +49,7 @@ module PsUtilities
     def array_append(array, value)
       index = update_path(:array_append)
       if @path[..0] == ['record']
-        @yield_record.call(value, index, @count)
+        @yield_record.call(value, index - 1, @count)
       else
         array << value
       end

--- a/lib/ps_utilities/version.rb
+++ b/lib/ps_utilities/version.rb
@@ -1,5 +1,5 @@
 module PsUtilities
   module Version
-    VERSION = "1.0.3"
+    VERSION = "1.1.0"
   end
 end

--- a/ps_utilities.gemspec
+++ b/ps_utilities.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*.rb']
 
   spec.add_dependency "httparty", '~> 0.18'
+  spec.add_dependency "oj", "~> 3.13"
+  spec.add_dependency "piperator", "~> 1.2"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This PR enables support for streaming JSON responses.

When a block is passed the `Connection#run` method, the response is processed by a JSON stream parser and iterates over the `record` attribute of the response JSON. A block was not previously handled.

```ruby
require_relative 'lib/ps_utilities'

# ENV['PS_BASE_URI'] = 'https://psdev.tulsaschools.org/'
# ENV['PS_CLIENT_ID'] = '********-****-****-****-************'
# ENV['PS_CLIENT_SECRET'] = '********-****-****-****-************'
connection = PsUtilities::Connection.new

## `pagesize=0` enables streaming responses from PowerSchool
## `count=true` enables including the count in the response from PowerSchool
command = :post
api_path = '/ws/schema/query/org.tulsaschools.data-thm-stored-grades.grades.historical_grades?pagesize=0&count=true'
options = {
  body: {
    '$q': 'storedgrades.termid=ge=3300;storedgrades.termid=lt=3400;storedgrades.datestored=ge=2024-02-01'
  }.to_json
}
connection.run(command:, api_path:, options:) do |record, index, count|
  puts "#{index+1}/#{count} #{record.slice('dcid', 'datestored')}"
end

1/668 {"dcid"=>"21315484", "datestored"=>"2024-02-01"}
2/668 {"dcid"=>"21315485", "datestored"=>"2024-02-01"}
3/668 {"dcid"=>"21315486", "datestored"=>"2024-02-01"}
…
666/668 {"dcid"=>"21318565", "datestored"=>"2024-03-01"}
667/668 {"dcid"=>"21318566", "datestored"=>"2024-03-01"}
668/668 {"dcid"=>"21318567", "datestored"=>"2024-03-01"}
```

## Resources
- https://support.powerschool.com/developer/#/page/powerqueries#streaming
- https://support.powerschool.com/developer/#/page/searching
- https://coderwall.com/p/l1omyw/ruby-reading-parsing-and-forwarding-large-json-files-in-small-chunks-i-e-streaming
- https://github.com/ohler55/oj …  Optimized JSON
- https://github.com/lautis/piperator …  Composable pipelines for Enumerators